### PR TITLE
Stackdriver

### DIFF
--- a/ext/gctrack/extconf.rb
+++ b/ext/gctrack/extconf.rb
@@ -1,5 +1,5 @@
 require 'mkmf'
 
-$CFLAGS = "-O3"
+$CFLAGS = "-O3 -Wall"
 
 create_makefile('gctrack/gctrack')

--- a/ext/gctrack/gctrack.c
+++ b/ext/gctrack/gctrack.c
@@ -40,7 +40,7 @@ Init_gctrack()
   VALUE mGC = rb_define_module("GC");
   VALUE cTracker = rb_define_class_under(mGC, "Tracker", rb_cData);
 
-  rb_define_singleton_method(cTracker, "enable", enable, -1);
+  rb_define_singleton_method(cTracker, "enable", enable, 0);
   rb_define_singleton_method(cTracker, "cycles", gc_cycles, 0);
   rb_define_singleton_method(cTracker, "disable", disable, 0);
 }

--- a/ext/gctrack/gctrack.c
+++ b/ext/gctrack/gctrack.c
@@ -7,8 +7,8 @@
 #include <stdlib.h>
 
 typedef struct {
-  unsigned long cycles;
-  unsigned long long duration;
+  uint32_t cycles;
+  uint64_t duration;
   void *parent;
 } record_t;
 
@@ -18,20 +18,20 @@ static ID id_tracepoint;
 static bool enabled = false;
 
 static record_t *last_record = NULL;
-static unsigned long long last_enter = 0;
+static uint64_t last_enter = 0;
 
-static unsigned long long 
+static uint64_t 
 nanotime()
 {
   struct timespec ts;
   if (clock_gettime(CLOCK_MONOTONIC, &ts) == -1) {
     rb_sys_fail("clock_gettime");
   }
-  return ts.tv_sec * (unsigned long long) 1000000000 + ts.tv_nsec;
+  return ts.tv_sec * (uint64_t) 1000000000 + ts.tv_nsec;
 }
 
 static inline void 
-add_gc_cycle(unsigned long long duration)
+add_gc_cycle(uint64_t duration)
 {
   record_t *record = last_record;
   while (record) {

--- a/ext/gctrack/gctrack.c
+++ b/ext/gctrack/gctrack.c
@@ -5,153 +5,11 @@
 #include <errno.h>
 #include <time.h>
 
-typedef struct gctrack_event_struct gctrack_event_t;
-struct gctrack_event_struct {
-  gctrack_event_t *next;
-  rb_event_flag_t ev;
-  struct timespec ts;
-};
-
-typedef struct {
-  VALUE proc;
-  VALUE ctx;
-  gctrack_event_t *events;
-} gctrack_hook_data_t;
-
-static VALUE cTracker = Qnil;
-static ID idCall;
 static bool enabled = false;
-
-static void
-hook_data_mark(void *ptr)
-{
-  gctrack_hook_data_t *hook_data = (gctrack_hook_data_t *) ptr;
-  rb_gc_mark(hook_data->proc);
-  if (!NIL_P(hook_data->ctx)) {
-    rb_gc_mark(hook_data->ctx);
-  }
-}
-
-static void
-hook_data_free(void *ptr)
-{
-  gctrack_hook_data_t *hook_data = (gctrack_hook_data_t *) ptr;
-  gctrack_event_t *p = hook_data->events;
-
-  while (p != NULL) {
-    gctrack_event_t *cur = p;
-    p = p->next;
-    free(cur);
-  }
-
-  free(hook_data);
-}
-
-static size_t
-hook_data_memsize(const void *ptr)
-{
-  gctrack_hook_data_t *data = (gctrack_hook_data_t *) ptr;
-  size_t sz = sizeof(gctrack_hook_data_t);
-
-  for (gctrack_event_t *p = data->events; p != NULL; p = p->next) {
-    sz += sizeof(gctrack_event_t);
-  }
-  return sz;
-}
-
-static const rb_data_type_t gctrack_hook_data_type = {
-  "gctrack_hook_data",
-  { hook_data_mark, hook_data_free, hook_data_memsize },
-  0, 0, RUBY_TYPED_FREE_IMMEDIATELY
-};
-
-static gctrack_event_t * alloc_event(gctrack_hook_data_t *data, bool *first)
-{
-  gctrack_event_t *ev = (gctrack_event_t *) calloc(1, sizeof(gctrack_event_t));
-  *first = false;
-  if (!data->events) {
-    data->events = ev;
-    *first = true;
-  } else {
-    gctrack_event_t *cur = data->events;
-    while (cur) {
-      if (cur->next == NULL) {
-        cur->next = ev;
-        break;
-      } else {
-        cur = cur->next;
-      }
-    }
-  }
-  return ev;
-}
-
-static void
-flush_gc_events(void *arg)
-{
-  gctrack_hook_data_t *hook_data = arg;
-
-  // TODO: convert gctrack_events to ruby array for the callback
-  rb_proc_call(hook_data->proc, rb_ary_new());
-}
-
-static void
-gc_event_hook(rb_event_flag_t event, VALUE data, VALUE self, ID id, VALUE klass)
-{
-  gctrack_hook_data_t *hook_data;
-  gctrack_event_t *ev;
-  bool first = false;
-
-  TypedData_Get_Struct(data, gctrack_hook_data_t, &gctrack_hook_data_type, hook_data);
-  ev = alloc_event(hook_data, &first);
-
-  clock_gettime(CLOCK_MONOTONIC_RAW, &ev->ts);
-  ev->ev = event;
-
-  if (first) {
-    rb_postponed_job_register(0, flush_gc_events, hook_data);
-  }
-}
 
 static VALUE
 enable(int argc, VALUE *argv, VALUE klass)
 {
-  gctrack_hook_data_t *data;
-  VALUE obj;
-  VALUE opts;
-  VALUE ctx = Qnil;
-
-  rb_event_flag_t events = RUBY_INTERNAL_EVENT_GC_ENTER |
-    RUBY_INTERNAL_EVENT_GC_EXIT;
-
-  if (enabled) {
-    return Qfalse;
-  }
-
-  if (!rb_block_given_p()) {
-    rb_raise(rb_eArgError, "called without a block");
-  }
-
-  rb_scan_args(argc, argv, ":", &opts);
-  if (!NIL_P(opts)) {
-    ID keys[2];
-    VALUE values[2];
-
-    keys[0] = rb_intern("context");
-    keys[1] = rb_intern("events");
-    rb_get_kwargs(opts, keys, 0, 2, values);
-    if (values[0] != Qundef) {
-      ctx = values[0];
-    }
-  }
-
-  obj = TypedData_Make_Struct(klass, gctrack_hook_data_t, &gctrack_hook_data_type, data);
-  data->proc = rb_block_proc();
-  data->ctx = ctx;
-  data->events = NULL;
-
-  rb_add_event_hook(gc_event_hook, events, obj);
-
   enabled = true;
 
   return Qtrue;
@@ -164,11 +22,6 @@ disable(VALUE self)
     return Qfalse;
   }
 
-  int ret = rb_remove_event_hook(gc_event_hook);
-  if (ret != 1) {
-    rb_raise(rb_eRuntimeError, "error removing event hook: %d", ret);
-  }
-
   enabled = false;
 
   return Qtrue;
@@ -178,10 +31,8 @@ void
 Init_gctrack()
 {
   VALUE mGC = rb_define_module("GC");
-  cTracker = rb_define_class_under(mGC, "Tracker", rb_cData);
+  VALUE cTracker = rb_define_class_under(mGC, "Tracker", rb_cData);
 
   rb_define_singleton_method(cTracker, "enable", enable, -1);
   rb_define_singleton_method(cTracker, "disable", disable, 0);
-
-  idCall = rb_intern("call");
 }

--- a/ext/gctrack/gctrack.c
+++ b/ext/gctrack/gctrack.c
@@ -85,19 +85,19 @@ gctracker_start_record(int argc, VALUE *argv, VALUE klass)
 static VALUE
 gctracker_end_record(int argc, VALUE *argv, VALUE klass)
 {
-  if (last_record) {
-    record_t *record = last_record;
-    last_record = record->parent;
-    
-    VALUE stats = rb_ary_new2(2);
-    rb_ary_store(stats, 0, ULONG2NUM(record->cycles));
-    rb_ary_store(stats, 1, ULONG2NUM(record->duration));
+  if (!last_record) {
+    return Qnil;
+  } 
+  record_t *record = last_record;
+  last_record = record->parent;
   
-    free(record);  
+  VALUE stats = rb_ary_new2(2);
+  rb_ary_store(stats, 0, ULONG2NUM(record->cycles));
+  rb_ary_store(stats, 1, ULONG2NUM(record->duration));
 
-    return stats;
-  }
-  return Qnil;
+  free(record);  
+
+  return stats;
 }
 
 static VALUE

--- a/ext/gctrack/gctrack.c
+++ b/ext/gctrack/gctrack.c
@@ -127,8 +127,11 @@ gctracker_enable(int argc, VALUE *argv, VALUE klass)
   }
 
   rb_tracepoint_enable(tracepoint);
-  
-  return gctracker_enabled() ? Qtrue : Qfalse;
+  if (!gctracker_enabled()) {
+    rb_raise(rb_eRuntimeError, "GCTracker: Couldn't enable tracepoint!");
+  }
+
+  return Qtrue;
 }
 
 static VALUE
@@ -140,7 +143,7 @@ gctracker_disable(VALUE self)
 
   rb_tracepoint_disable(tracepoint);
   if (gctracker_enabled()) {
-    return Qfalse;
+    rb_raise(rb_eRuntimeError, "GCTracker: Couldn't disable tracepoint!");
   } 
 
   while (last_record) {

--- a/ext/gctrack/gctrack.c
+++ b/ext/gctrack/gctrack.c
@@ -5,6 +5,9 @@
 #include <errno.h>
 #include <time.h>
 
+static VALUE mGC;
+static ID id_tracepoint;
+
 static bool enabled = false;
 static unsigned long cycles = 0;
 
@@ -14,31 +17,65 @@ gc_cycles(int argc, VALUE *argv, VALUE klass)
   return ULONG2NUM(cycles);
 }
 
+static void gc_hook(VALUE tpval, void *data)
+{
+  if (!enabled) {
+      return;
+  }
+  rb_trace_arg_t *tparg = rb_tracearg_from_tracepoint(tpval);
+  switch (rb_tracearg_event_flag(tparg)) {
+      case RUBY_INTERNAL_EVENT_GC_ENTER:
+          break;
+      case RUBY_INTERNAL_EVENT_GC_EXIT:
+          cycles++;
+          break;
+  }
+}
+
 static VALUE
 enable(int argc, VALUE *argv, VALUE klass)
 {
+  if (NIL_P(rb_ivar_get(mGC, id_tracepoint))) {
+    rb_event_flag_t events;
+    events = RUBY_INTERNAL_EVENT_GC_START | RUBY_INTERNAL_EVENT_GC_END_MARK | RUBY_INTERNAL_EVENT_GC_END_SWEEP;
+    events |= RUBY_INTERNAL_EVENT_GC_ENTER | RUBY_INTERNAL_EVENT_GC_EXIT;
+    VALUE tracepoint = rb_tracepoint_new(0, events, gc_hook, (void *)0);
+    if (NIL_P(tracepoint)) { 
+      return Qfalse;
+    }
+    rb_tracepoint_enable(tracepoint);
+    rb_ivar_set(mGC, id_tracepoint, tracepoint);
+  }
+  
   enabled = true;
-
   return Qtrue;
 }
 
 static VALUE
 disable(VALUE self)
 {
-  if (!enabled) {
+  VALUE tracepoint = rb_ivar_get(mGC, id_tracepoint);  
+  if (NIL_P(tracepoint)) {
     return Qfalse;
   }
 
-  enabled = false;
+  cycles = 0; // todo kill this!
 
+  rb_tracepoint_disable(tracepoint);
+  rb_ivar_set(mGC, id_tracepoint, Qnil);
+  enabled = false;
+  
   return Qtrue;
 }
 
 void
 Init_gctrack()
 {
-  VALUE mGC = rb_define_module("GC");
+  mGC = rb_define_module("GC");
   VALUE cTracker = rb_define_class_under(mGC, "Tracker", rb_cData);
+
+  id_tracepoint = rb_intern("__gc_tracepoint");  
+  rb_ivar_set(mGC, id_tracepoint, Qnil);
 
   rb_define_singleton_method(cTracker, "enable", enable, 0);
   rb_define_singleton_method(cTracker, "cycles", gc_cycles, 0);

--- a/ext/gctrack/gctrack.c
+++ b/ext/gctrack/gctrack.c
@@ -4,70 +4,93 @@
 #include <stdbool.h>
 #include <errno.h>
 #include <time.h>
+#include <stdlib.h>
 
 typedef struct {
   unsigned long cycles;
-  unsigned long duration;
+  unsigned long long duration;
   void *parent;
-} stat_record;
+} record_t;
 
-static VALUE mGC;
+static VALUE cTracker;
 static ID id_tracepoint;
 
 static bool enabled = false;
 
-static stat_record *last_record = NULL;
-static unsigned long last_enter;
+static record_t *last_record = NULL;
+static unsigned long long last_enter = 0;
 
-static unsigned long nanotime()
+static unsigned long long 
+nanotime()
 {
   struct timespec ts;
   if (clock_gettime(CLOCK_MONOTONIC, &ts) == -1) {
     rb_sys_fail("clock_gettime");
   }
-  return ts.tv_sec * 1e9 + ts.tv_nsec;
+  return ts.tv_sec * (unsigned long long) 1000000000 + ts.tv_nsec;
 }
 
-static void gc_hook(VALUE tpval, void *data)
+static inline void 
+add_gc_cycle(unsigned long long duration)
 {
-  if (!enabled || !last_record) {
-      return;
+  record_t *record = last_record;
+  while (record) {
+    record->cycles = record->cycles + 1;
+    record->duration = record->duration + duration;
+    record = (record_t *) record->parent;
+  }
+}
+
+static void 
+gctracker_hook(VALUE tpval, void *data)
+{
+  if (!enabled) {
+    return;
   }
   rb_trace_arg_t *tparg = rb_tracearg_from_tracepoint(tpval);
   switch (rb_tracearg_event_flag(tparg)) {
-      case RUBY_INTERNAL_EVENT_GC_ENTER:
-        last_enter = nanotime();
-        break;
-      case RUBY_INTERNAL_EVENT_GC_EXIT:
-        last_record->cycles++;
-        last_record->duration += nanotime() - last_enter;
-        break;
+    case RUBY_INTERNAL_EVENT_GC_ENTER: {
+      last_enter = nanotime();
+    }
+      break;
+    case RUBY_INTERNAL_EVENT_GC_EXIT: {
+      if (last_enter) {
+        add_gc_cycle(nanotime() - last_enter);
+      }
+      last_enter = 0;
+    }
+      break;
   }
 }
 
 static VALUE
-start_record(int argc, VALUE *argv, VALUE klass)
+gctracker_start_record(int argc, VALUE *argv, VALUE klass)
 {
-  stat_record *record = calloc(1, sizeof(start_record));
+  if(!enabled) {
+    return Qfalse;
+  }
+
+  record_t *record = (record_t *) calloc(1, sizeof(record_t));
   if (!record) {
     return Qfalse;
-  }    
+  }
+  
   record->parent = last_record;
   last_record = record;
   return Qtrue;
 }
 
 static VALUE
-end_record(int argc, VALUE *argv, VALUE klass)
+gctracker_end_record(int argc, VALUE *argv, VALUE klass)
 {
   if (last_record) {
-    stat_record *record = last_record;
-  
+    record_t *record = last_record;
+    last_record = (record_t *) record->parent;
+    
     VALUE stats = rb_ary_new2(2);
     rb_ary_store(stats, 0, ULONG2NUM(record->cycles));
     rb_ary_store(stats, 1, ULONG2NUM(record->duration));
   
-    last_record = record->parent;
     free(record);  
 
     return stats;
@@ -76,51 +99,49 @@ end_record(int argc, VALUE *argv, VALUE klass)
 }
 
 static VALUE
-enable(int argc, VALUE *argv, VALUE klass)
+gctracker_enable(int argc, VALUE *argv, VALUE klass)
 {
-  VALUE tracepoint = rb_ivar_get(mGC, id_tracepoint);
+  VALUE tracepoint = rb_ivar_get(cTracker, id_tracepoint);
   if (NIL_P(tracepoint)) {
+    enabled = true;
     rb_event_flag_t events;
-    events = RUBY_INTERNAL_EVENT_GC_START | RUBY_INTERNAL_EVENT_GC_END_MARK | RUBY_INTERNAL_EVENT_GC_END_SWEEP;
-    events |= RUBY_INTERNAL_EVENT_GC_ENTER | RUBY_INTERNAL_EVENT_GC_EXIT;
-    VALUE tracepoint = rb_tracepoint_new(0, events, gc_hook, (void *)0);
+    events = RUBY_INTERNAL_EVENT_GC_ENTER | RUBY_INTERNAL_EVENT_GC_EXIT;
+    tracepoint = rb_tracepoint_new(0, events, gctracker_hook, (void *) NULL);
     if (NIL_P(tracepoint)) { 
+      enabled = false;
       return Qfalse;
     }
+    rb_ivar_set(cTracker, id_tracepoint, tracepoint);
     rb_tracepoint_enable(tracepoint);
-    rb_ivar_set(mGC, id_tracepoint, tracepoint);
+  } else if (!enabled) {
     enabled = true;
-  } else {
-    if (!enabled) {
-      enabled = true;
-      rb_raise(rb_eTypeError, "GC::Tracker: CORRUPTED FSM!");
-    }
+    rb_raise(rb_eTypeError, "GCTracker: CORRUPTED FSM!");
   }
-
+  
   return Qtrue;
 }
 
 static VALUE
-disable(VALUE self)
+gctracker_disable(VALUE self)
 {
-  VALUE tracepoint = rb_ivar_get(mGC, id_tracepoint);  
+  VALUE tracepoint = rb_ivar_get(cTracker, id_tracepoint);  
   if (NIL_P(tracepoint)) {
     if (enabled) {
       enabled = false;
-      rb_raise(rb_eTypeError, "GC::Tracker: CORRUPTED FSM!");
+      rb_raise(rb_eTypeError, "GCTracker: CORRUPTED FSM!");
     }
     return Qfalse;
   }
 
+  rb_tracepoint_disable(tracepoint);
+  rb_ivar_set(cTracker, id_tracepoint, Qnil);
+  enabled = false;
   while (last_record) {
-    stat_record *record = last_record;
-    last_record = record->parent;
+    record_t *record = last_record;
+    last_record = (record_t *) record->parent;
     free(record);
   }
-
-  rb_tracepoint_disable(tracepoint);
-  rb_ivar_set(mGC, id_tracepoint, Qnil);
-  enabled = false;
+  last_record = NULL;
   
   return Qtrue;
 }
@@ -128,15 +149,15 @@ disable(VALUE self)
 void
 Init_gctrack()
 {
-  mGC = rb_define_module("GC");
-  VALUE cTracker = rb_define_class_under(mGC, "Tracker", rb_cData);
+  VALUE mGC = rb_define_module("GC");
+  cTracker = rb_define_module_under(mGC, "Tracker");
 
   id_tracepoint = rb_intern("__gc_tracepoint");  
-  rb_ivar_set(mGC, id_tracepoint, Qnil);
+  rb_ivar_set(cTracker, id_tracepoint, Qnil);
 
-  rb_define_singleton_method(cTracker, "enable", enable, 0);
-  rb_define_singleton_method(cTracker, "disable", disable, 0);
+  rb_define_module_function(cTracker, "enable", gctracker_enable, 0);
+  rb_define_module_function(cTracker, "disable", gctracker_disable, 0);
 
-  rb_define_singleton_method(cTracker, "start_record", start_record, 0);
-  rb_define_singleton_method(cTracker, "end_record", end_record, 0);
+  rb_define_module_function(cTracker, "start_record", gctracker_start_record, 0);
+  rb_define_module_function(cTracker, "end_record", gctracker_end_record, 0);
 }

--- a/ext/gctrack/gctrack.c
+++ b/ext/gctrack/gctrack.c
@@ -6,6 +6,13 @@
 #include <time.h>
 
 static bool enabled = false;
+static unsigned long cycles = 0;
+
+static VALUE
+gc_cycles(int argc, VALUE *argv, VALUE klass)
+{
+  return ULONG2NUM(cycles);
+}
 
 static VALUE
 enable(int argc, VALUE *argv, VALUE klass)
@@ -34,5 +41,6 @@ Init_gctrack()
   VALUE cTracker = rb_define_class_under(mGC, "Tracker", rb_cData);
 
   rb_define_singleton_method(cTracker, "enable", enable, -1);
+  rb_define_singleton_method(cTracker, "cycles", gc_cycles, 0);
   rb_define_singleton_method(cTracker, "disable", disable, 0);
 }

--- a/test/test_gctrack.rb
+++ b/test/test_gctrack.rb
@@ -10,6 +10,10 @@ class TestGctrack < Test::Unit::TestCase
 
   def test_disable
     assert !GC::Tracker.disable
+    assert GC::Tracker.enable
+    assert GC::Tracker.enable
+    assert GC::Tracker.disable
+    assert !GC::Tracker.disable
   end
 
   def test_returns_false_when_not_enabled

--- a/test/test_gctrack.rb
+++ b/test/test_gctrack.rb
@@ -5,7 +5,11 @@ class TestGctrack < Test::Unit::TestCase
   def test_enable
     assert GC::Tracker.enable
   ensure
-    assert GC::Tracker.disable
+    GC::Tracker.disable
+  end
+
+  def test_disable
+    assert !GC::Tracker.disable
   end
 
   def test_returns_false_when_not_enabled
@@ -14,6 +18,12 @@ class TestGctrack < Test::Unit::TestCase
 
   def test_enabled_generates_events
     assert_equal 0, GC::Tracker.cycles
+    assert GC::Tracker.enable
+    GC.start
+    assert GC::Tracker.cycles > 0
+  ensure
+    GC::Tracker.disable
+    assert GC::Tracker.cycles == 0
   end
 end
 

--- a/test/test_gctrack.rb
+++ b/test/test_gctrack.rb
@@ -13,6 +13,7 @@ class TestGctrack < Test::Unit::TestCase
   end
 
   def test_enabled_generates_events
+    assert_equal 0, GC::Tracker.cycles
   end
 end
 

--- a/test/test_gctrack.rb
+++ b/test/test_gctrack.rb
@@ -21,15 +21,14 @@ class TestGctrack < Test::Unit::TestCase
   end
 
   def test_enabled_generates_events
-    assert_equal 0, GC::Tracker.cycles
     assert GC::Tracker.enable
     assert GC::Tracker.start_record
     GC.start
-    assert GC::Tracker.cycles > 0
-    assert GC::Tracker.duration > 0
+    cycles, duration = GC::Tracker.end_record
+    assert cycles > 0
+    assert duration > 0
   ensure
     GC::Tracker.disable
-    assert GC::Tracker.cycles == 0
   end
 end
 

--- a/test/test_gctrack.rb
+++ b/test/test_gctrack.rb
@@ -25,6 +25,7 @@ class TestGctrack < Test::Unit::TestCase
     assert GC::Tracker.enable
     GC.start
     assert GC::Tracker.cycles > 0
+    assert GC::Tracker.duration > 0
   ensure
     GC::Tracker.disable
     assert GC::Tracker.cycles == 0

--- a/test/test_gctrack.rb
+++ b/test/test_gctrack.rb
@@ -11,9 +11,7 @@ class TestGctrack < Test::Unit::TestCase
   def test_disable
     assert !GC::Tracker.disable
     assert GC::Tracker.enable
-    assert GC::Tracker.enable
     assert GC::Tracker.disable
-    assert !GC::Tracker.disable
   end
 
   def test_returns_false_when_not_enabled
@@ -27,6 +25,37 @@ class TestGctrack < Test::Unit::TestCase
     cycles, duration = GC::Tracker.end_record
     assert cycles > 0
     assert duration > 0
+  ensure
+    GC::Tracker.disable
+  end
+
+  def test_recurses
+    assert GC::Tracker.enable
+    assert GC::Tracker.start_record
+    a = "a"
+    10.times { |i| a += a * i }
+    GC.start
+    assert GC::Tracker.start_record
+    a = "a"
+    10.times { |i| a += a * i }
+    cycles_c, duration_c = GC::Tracker.end_record
+    cycles_p, duration_p = GC::Tracker.end_record
+    assert cycles_p > cycles_c
+    assert duration_p > duration_c
+  ensure
+    GC::Tracker.disable
+  end
+
+  def test_no_data_when_disabled
+    assert !GC::Tracker.start_record
+    assert GC::Tracker.end_record.nil?
+  end
+
+  def test_no_data_for_started_records_on_disable
+    assert GC::Tracker.enable
+    assert GC::Tracker.start_record
+    assert GC::Tracker.disable
+    assert GC::Tracker.end_record.nil?
   ensure
     GC::Tracker.disable
   end

--- a/test/test_gctrack.rb
+++ b/test/test_gctrack.rb
@@ -1,5 +1,5 @@
 require 'test/unit'
-require 'gctrack'
+require 'gctrack/gctrack'
 
 class TestGctrack < Test::Unit::TestCase
   def test_enable
@@ -13,21 +13,6 @@ class TestGctrack < Test::Unit::TestCase
   end
 
   def test_enabled_generates_events
-    called = false
-
-    GC::Tracker.enable do
-      called = true
-    end
-    GC.start
-
-    # TODO: There is some *weird* VM issue happening here, where the update to
-    # `called` is not immediately visible until its been accessed. By reading
-    # `called` here, it seems to somehow force the local to be updated.
-    nil if called
-
-    assert called
-  ensure
-    GC::Tracker.disable
   end
 end
 

--- a/test/test_gctrack.rb
+++ b/test/test_gctrack.rb
@@ -23,6 +23,7 @@ class TestGctrack < Test::Unit::TestCase
   def test_enabled_generates_events
     assert_equal 0, GC::Tracker.cycles
     assert GC::Tracker.enable
+    assert GC::Tracker.start_record
     GC.start
     assert GC::Tracker.cycles > 0
     assert GC::Tracker.duration > 0

--- a/test/test_gctrack.rb
+++ b/test/test_gctrack.rb
@@ -3,9 +3,9 @@ require 'gctrack/gctrack'
 
 class TestGctrack < Test::Unit::TestCase
   def test_enable
-    GC::Tracker.enable { }
+    assert GC::Tracker.enable
   ensure
-    GC::Tracker.disable
+    assert GC::Tracker.disable
   end
 
   def test_returns_false_when_not_enabled


### PR DESCRIPTION
This let's one recursively gather GC cycle data (amount & overall duration):

```ruby
GC::Tracker.enable
GC::Tracker.start_record
 # do stuff
GC::Tracker.start_record # starts a second record
 # do moar stuff
cycles_for_last_records_span, duration_for_last_records_span = GC::Tracker.end_record
cycles_for_first_records_span, duration_for_first_records_span = GC::Tracker.end_record
```