### PR TITLE
Saner #enable & #disable contract

### DIFF
--- a/ext/gctrack/gctrack.c
+++ b/ext/gctrack/gctrack.c
@@ -70,16 +70,17 @@ gctracker_hook(VALUE tpval, void *data)
   }
 }
 
-static void
+static bool
 create_tracepoint() 
 {
   rb_event_flag_t events;
   events = RUBY_INTERNAL_EVENT_GC_ENTER | RUBY_INTERNAL_EVENT_GC_EXIT;
   tracepoint = rb_tracepoint_new(0, events, gctracker_hook, (void *) NULL);
   if (NIL_P(tracepoint)) {
-    rb_raise(rb_eRuntimeError, "GCTracker: Couldn't create tracepoint!");
+    return false;
   }
   rb_global_variable(&tracepoint);
+  return true;
 }
 
 static VALUE
@@ -125,12 +126,14 @@ gctracker_enable(int argc, VALUE *argv, VALUE klass)
   }
 
   if (NIL_P(tracepoint)) {
-    create_tracepoint();
+    if(!create_tracepoint()) {
+      return Qfalse;
+    }
   }
 
   rb_tracepoint_enable(tracepoint);
   if (!gctracker_enabled()) {
-    rb_raise(rb_eRuntimeError, "GCTracker: Couldn't enable tracepoint!");
+    return Qfalse;
   }
 
   return Qtrue;

--- a/ext/gctrack/gctrack.c
+++ b/ext/gctrack/gctrack.c
@@ -149,12 +149,12 @@ static VALUE
 gctracker_disable(VALUE self)
 {
   if (!gctracker_enabled()) {
-    return Qfalse;
+    return Qtrue;
   }
 
   rb_tracepoint_disable(tracepoint);
   if (gctracker_enabled()) {
-    rb_raise(rb_eRuntimeError, "GCTracker: Couldn't disable tracepoint!");
+    return Qfalse;
   } 
   
   return Qtrue;

--- a/ext/gctrack/gctrack.c
+++ b/ext/gctrack/gctrack.c
@@ -118,6 +118,12 @@ gctracker_end_record(int argc, VALUE *argv, VALUE klass)
   return stats;
 }
 
+static VALUE 
+gctracker_enabled_p(int argc, VALUE *argv, VALUE klass)
+{
+  return gctracker_enabled() ? Qtrue : Qfalse;
+}
+
 static VALUE
 gctracker_enable(int argc, VALUE *argv, VALUE klass)
 {
@@ -161,6 +167,7 @@ Init_gctrack()
   VALUE cTracker = rb_define_module_under(mGC, "Tracker");
 
   rb_define_module_function(cTracker, "enable", gctracker_enable, 0);
+  rb_define_module_function(cTracker, "enabled?", gctracker_enabled_p, 0);
   rb_define_module_function(cTracker, "disable", gctracker_disable, 0);
 
   rb_define_module_function(cTracker, "start_record", gctracker_start_record, 0);

--- a/test/test_gctrack.rb
+++ b/test/test_gctrack.rb
@@ -51,6 +51,14 @@ class TestGctrack < Test::Unit::TestCase
     assert GC::Tracker.end_record.nil?
   end
 
+  def test_enabled_returns_accrodingly
+    assert !GC::Tracker.enabled?
+    GC::Tracker.enable
+    assert GC::Tracker.enabled?
+  ensure
+    GC::Tracker.disable
+  end
+
   def test_data_for_started_records_on_disable
     assert GC::Tracker.enable
     assert GC::Tracker.start_record

--- a/test/test_gctrack.rb
+++ b/test/test_gctrack.rb
@@ -9,13 +9,9 @@ class TestGctrack < Test::Unit::TestCase
   end
 
   def test_disable
-    assert !GC::Tracker.disable
+    assert GC::Tracker.disable
     assert GC::Tracker.enable
     assert GC::Tracker.disable
-  end
-
-  def test_returns_false_when_not_enabled
-    assert_equal false, GC::Tracker.disable
   end
 
   def test_enabled_generates_events

--- a/test/test_gctrack.rb
+++ b/test/test_gctrack.rb
@@ -51,10 +51,12 @@ class TestGctrack < Test::Unit::TestCase
     assert GC::Tracker.end_record.nil?
   end
 
-  def test_no_data_for_started_records_on_disable
+  def test_data_for_started_records_on_disable
     assert GC::Tracker.enable
     assert GC::Tracker.start_record
     assert GC::Tracker.disable
+    assert !GC::Tracker.start_record
+    assert !GC::Tracker.end_record.nil?
     assert GC::Tracker.end_record.nil?
   ensure
     GC::Tracker.disable


### PR DESCRIPTION
`GC::Tracker#enable` will never throw, instead return `false` on failure.

`GC::Tracker#disable` will let `.end_record` be called for collecting "started" record, while not allowing for nay further `start_record` (i.e. it'll return `false` from there on). 

I think this makes more sense in a multithreaded environment, where you'd want to disable, while other threads are still doing work. If `GC::Tracker#start_record` return `true` you are guaranteed that the matching `#end_record` _will return data_. 

I've also somewhat tweaked the `#enable`, so it returns "faster" (roflscale).