### PR TITLE
Adding allocation counter to records

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    gctrack (0.1.0)
+    gctrack (0.2.0)
 
 GEM
   remote: https://rubygems.org/
@@ -37,4 +37,4 @@ DEPENDENCIES
   test-unit
 
 BUNDLED WITH
-   1.15.3
+   1.17.3

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ GCTrack is published to [rubygems.org](https://rubygems.org/gems/gctrack).
 Simply add it as a dependency to your `Gemfile`
 
 ```ruby
-gem 'gctrack', '~> 0.1.0'
+gem 'gctrack', '~> 0.2.0'
 ```
 
 #### #2 Enable the extension
@@ -29,11 +29,12 @@ GC::Tracker.enable # returns true, if the Tracker is now enabled
 ```ruby
 GC::Tracker.start_record # returns true, if a new record was started
 # DO ACTUAL WORK
-gc_cycles, gc_duration_ns = GC::Tracker.end_record
+gc_cycles, gc_duration_ns, object_allocations = GC::Tracker.end_record
 ```
 
 `#end_record` will return the `gc_cycles` (the amount of gc cycles observed) and `gc_duration_ns` (their cumulative duration in 
-nanoseconds), since the last invocation of `#start_record`. You can also invoke `#start_record` recursively as so:
+nanoseconds), `object_allocations` is the number of object creations, since the last invocation of `#start_record`. 
+You can also invoke `#start_record` recursively as so:
 
 ```ruby
 GC::Tracker.start_record # Start a first record 

--- a/ext/gctrack/gctrack.c
+++ b/ext/gctrack/gctrack.c
@@ -101,10 +101,10 @@ create_tracepoint()
  *    GC::Tracker.enabled?      # true
  *    GC::Tracker.start_record  # true
  *    GC::Tracker.start_record  # true
- *    GC::Tracker.end_record    # [2, 12654] from the second #start_record
+ *    GC::Tracker.end_record    # [2, 12654, 254] from the second #start_record
  *    GC::Tracker.disable       # true
  *    GC::Tracker.start_record  # false
- *    GC::Tracker.end_record    # [3, 15782] from the first #start_record, contains the data from the first record
+ *    GC::Tracker.end_record    # [3, 15782, 537] from the first #start_record, contains the data from the first record
  *    GC::Tracker.end_record    # nil from the last #start_record, that returned false
  */
 static VALUE
@@ -131,16 +131,16 @@ gctracker_start_record(int argc, VALUE *argv, VALUE klass)
  *
  * Ends the recording of the last started record and return the 
  * the collected information. 
- * The array contains two numbers: The amount of GC cycles observed and 
- * the cumulative duration in nanoseconds of these cycles. If multiple recordings
- * were started they will be be popped from the stack of records and their 
+ * The array contains three numbers: The amount of GC cycles observed,
+ * the cumulative duration in nanoseconds of these cycles and the amount of objects allocated. 
+ * If multiple recordings were started they will be be popped from the stack of records and their 
  * values will be returned. 
  * GC data gathered is in all records of the stack. 
  *
  *    GC::Tracker.start_record  # true
  *    GC::Tracker.start_record  # true
- *    GC::Tracker.end_record    # [2, 12654] amount of cycles and duration since the second #start_record
- *    GC::Tracker.end_record    # [3, 15782] GC data since the first #start_record, including the data above
+ *    GC::Tracker.end_record    # [2, 12654, 34534] amount of GC cycles and duration as well as objects allocated since the second #start_record
+ *    GC::Tracker.end_record    # [3, 15782, 35678] GC data & allocations since the first #start_record, including the data above
  *    GC::Tracker.disable       # true
  *    GC::Tracker.start_record  # false
  *    GC::Tracker.end_record    # nil

--- a/gctrack.gemspec
+++ b/gctrack.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'gctrack'
-  s.version = '0.1.0'
+  s.version = '0.2.0'
   s.summary = 'Track Ruby GC events'
   s.description = <<-DOC
     This gem can be used to track Ruby GC tracepoints that are normally only visible through GC extensions.

--- a/test/bench.rb
+++ b/test/bench.rb
@@ -1,0 +1,31 @@
+require_relative '../lib/gctrack/gctrack'
+require 'benchmark'
+
+def create_garbage(and_gc: false) 
+  a = "a"
+  10.times { |i| a += a * i }
+  GC.start if and_gc
+end
+
+def test(width: 50, depth: 300)
+  GC::Tracker.start_record
+  width.times do 
+    GC::Tracker.start_record
+    create_garbage(and_gc: true)
+    depth.times do 
+      GC::Tracker.start_record 
+      create_garbage
+    end
+    depth.times { GC::Tracker.end_record }
+    GC::Tracker.end_record
+  end
+  GC::Tracker.end_record
+end
+
+raise "Couldn't enable GC::Tracker!" unless GC::Tracker.enable
+3.times do
+  GC::Tracker.start_record
+  puts Benchmark.measure { test() }
+  cycles, duration, allocs = GC::Tracker.end_record
+  puts "For #{cycles} GC Cycles summing to #{(duration.to_f / 1_000_000).round(3)}ms while we allocated #{allocs} objects!"
+end


### PR DESCRIPTION
@csfrancis Here's a first pass at what we discussed: adding allocation counters to records.

 - [x] Add some benchmark to see the impact of this
 - ~Could (en|dis)able counters as params to `GC::Tracker.start_record`~ (don't think we need this, based of [benchmark results](https://github.com/Shopify/gctrack/pull/9#issuecomment-454777823)) 